### PR TITLE
feature(i18n):add nested argument and string interpolation

### DIFF
--- a/helpers/i18n.js
+++ b/helpers/i18n.js
@@ -1,16 +1,29 @@
-/** 
+/**
  *  i18n handlebars helper
  *
  *  Хелпер для работы с rails локалями на клиенте.
  *
- * @param key {string} - уникальный идентификатор нужной строки
- * @example {{ i18n 'unique.locale.string.name' }}
+ * @param key {string} - уникальный идентификатор нужной строки. будет искать вложенные ключи, разделённые точкой (.)
+ * @param options.hash {object} - пары ключ: значение для интерполяции параметров %{param}
+ * @example {{ i18n 'unique.locale.string.name' email="example@mail.ru" }}
  */
-const i18n = function(key) {
-  const 
-    errorMessage = 'translation missing app.i18n["' + key + '"]';
+const i18n = function(key, options) {
+  const
+    errorMessage = 'translation missing app.i18n["' + key + '"]',
+    interpolateRegExp = /%{(\w+)}/g;
 
-  return (window.app.i18n && window.app.i18n[key]) || errorMessage;
+  try {
+    let
+      translation = key.split('.').reduce(function(translation, key) {
+        return translation[key];
+      }, window.app.i18n);
+
+    return translation.replace(interpolateRegExp, function(match, key) {
+      return options.hash[key];
+    });
+  } catch(err) {
+    return errorMessage;
+  }
 };
 
 module.exports = i18n;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apress/handlebars-helpers",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "apress handlebars helpers pack",
   "main": "README.md",
   "scripts": {

--- a/test/i18n.js/helper.js
+++ b/test/i18n.js/helper.js
@@ -1,9 +1,12 @@
 let backupWindow;
 
-const 
+const
   TEST_LOCALE_VALUE = `test locale string`,
-  TEST_LOCALE_KEY   = `test.locale.key`,
-  TEST_LOCALE_ERROR = `translation missing app.i18n["${TEST_LOCALE_KEY}"]`;
+  TEST_LOCALE_INTERPOLATED_PARAM = '%{param}',
+  TEST_LOCALE_KEY   = `test_locale_key`,
+  TEST_LOCALE_NESTED_KEY   = `test.locale.key`,
+  TEST_LOCALE_ERROR = `translation missing app.i18n["${TEST_LOCALE_KEY}"]`,
+  TEST_LOCALE_NESTED_ERROR = `translation missing app.i18n["${TEST_LOCALE_NESTED_KEY}"]`;
 
 
 module.exports = {
@@ -20,7 +23,22 @@ module.exports = {
     global.window = mock;
   },
 
+  optionsStub(hash) {
+    return { hash: hash };
+  },
+
+  i18nNestedStub(value) {
+    return {
+      test: {
+        locale: { key: value || TEST_LOCALE_VALUE }
+      }
+    };
+  },
+
   TEST_LOCALE_KEY,
+  TEST_LOCALE_NESTED_KEY,
   TEST_LOCALE_VALUE,
-  TEST_LOCALE_ERROR
+  TEST_LOCALE_INTERPOLATED_PARAM,
+  TEST_LOCALE_ERROR,
+  TEST_LOCALE_NESTED_ERROR
 };

--- a/test/i18n.js/i18n.js
+++ b/test/i18n.js/i18n.js
@@ -1,10 +1,10 @@
-const 
+const
   assert = require('assert');
 
-const 
+const
   i18n = require('../../helpers/i18n');
 
-const 
+const
   helper = require('./helper.js');
 
 describe('i18n helper', () => {
@@ -36,5 +36,63 @@ describe('i18n helper', () => {
     helper.mockWindow({ app: { i18n: {} } });
 
     assert.strictEqual(helper.TEST_LOCALE_ERROR, i18n(helper.TEST_LOCALE_KEY));
+  });
+
+  it(`should return nested value`, () => {
+    helper.mockWindow({ app: { i18n: helper.i18nNestedStub() } });
+
+    assert.strictEqual(helper.TEST_LOCALE_VALUE, i18n(helper.TEST_LOCALE_NESTED_KEY));
+  });
+
+  it(`should return error message, when nested value doesn't exist`, () => {
+    const
+      app = { i18n: { test: { key: helper.TEST_LOCALE_VALUE } } };
+
+    helper.mockWindow({ app: app });
+
+    assert.strictEqual(helper.TEST_LOCALE_NESTED_ERROR, i18n(helper.TEST_LOCALE_NESTED_KEY));
+  });
+
+  it(`should return error message, when nested value is undefined`, () => {
+    const
+      app = { i18n: { test: { locale: { } } } };
+
+    helper.mockWindow({ app: app });
+
+    assert.strictEqual(helper.TEST_LOCALE_NESTED_ERROR, i18n(helper.TEST_LOCALE_NESTED_KEY));
+  });
+
+  it(`should interpolate value with param`, () => {
+    const
+      interpolatedValue = 'value',
+      options = helper.optionsStub({ param: interpolatedValue });
+
+    helper.mockWindow({
+      app: {
+        i18n: { [helper.TEST_LOCALE_KEY]: helper.TEST_LOCALE_VALUE + ' ' + helper.TEST_LOCALE_INTERPOLATED_PARAM }
+      }
+    });
+
+    assert.strictEqual(
+      helper.TEST_LOCALE_VALUE + ' ' + interpolatedValue,
+      i18n(helper.TEST_LOCALE_KEY, options)
+    );
+  });
+
+  it(`should interpolate nested value with param`, () => {
+    const
+      interpolatedValue = 'value',
+      options = helper.optionsStub({ param: interpolatedValue });
+
+    helper.mockWindow({
+      app: {
+        i18n: helper.i18nNestedStub(helper.TEST_LOCALE_VALUE + ' ' + helper.TEST_LOCALE_INTERPOLATED_PARAM)
+      }
+    });
+
+    assert.strictEqual(
+      helper.TEST_LOCALE_VALUE + ' ' + interpolatedValue,
+      i18n(helper.TEST_LOCALE_NESTED_KEY, options)
+    );
   });
 });


### PR DESCRIPTION
[MAJOR] Добавит возможность доставать строки из вложенных объектов.
Уровни вложенности разделяются точкой (.), поэтому для
перехода на новую версию необходимо заменить все ключи локалей, содержащие
точку, или положить соответствующие локали во вложенные объекты.
Например 'unique.locale.string.name'заменить на 'unique_locale_string_name'
Добавит возможность интерполировать параметры строки заданные через %{param}.
Пример {{ i18n 'unique.locale.string.name' email="some@mail.ru" }}